### PR TITLE
Add the host to sequelize initialization

### DIFF
--- a/_helpers/db.js
+++ b/_helpers/db.js
@@ -13,7 +13,7 @@ async function initialize() {
     await connection.query(`CREATE DATABASE IF NOT EXISTS \`${database}\`;`);
 
     // connect to db
-    const sequelize = new Sequelize(database, user, password, { dialect: 'mysql' });
+    const sequelize = new Sequelize(database, user, password, { host: host, dialect: 'mysql' });
 
     // init models and add them to the exported db object
     db.Account = require('../accounts/account.model')(sequelize);


### PR DESCRIPTION
Otherwise you might wonder for hours why the host from config.json
is being resolved to 127.0.0.1 all the time, when you run your db on a
remote host or this backend is in a container.